### PR TITLE
breakchange: 将 AddDomainEvent 方法的访问修饰符从 public 修改为 protected

### DIFF
--- a/src/Domain.Abstractions/Entity.cs
+++ b/src/Domain.Abstractions/Entity.cs
@@ -13,10 +13,10 @@ namespace NetCorePal.Extensions.Domain
 
         public override string ToString() => $"[Entity: {GetType().Name}] Keys = {string.Join(",", GetKeys())}";
 
-        private readonly List<IDomainEvent> _domainEvents = new();
+        private readonly List<IDomainEvent> _domainEvents = [];
         public IReadOnlyList<IDomainEvent> GetDomainEvents() => _domainEvents.AsReadOnly();
 
-        public void AddDomainEvent(IDomainEvent eventItem)
+        protected void AddDomainEvent(IDomainEvent eventItem)
         {
             _domainEvents.Add(eventItem);
         }
@@ -35,7 +35,7 @@ namespace NetCorePal.Extensions.Domain
 #pragma warning disable CS8618 // 在退出构造函数时，不可为 null 的字段必须包含非 null 值。请考虑声明为可以为 null。
         public virtual TKey Id { get; protected set; }
 #pragma warning restore CS8618 // 在退出构造函数时，不可为 null 的字段必须包含非 null 值。请考虑声明为可以为 null。
-        public override object[] GetKeys() => new object[] { Id };
+        public override object[] GetKeys() => [Id];
 
         public override bool Equals(object? obj)
         {

--- a/src/NetCorePal.Extensions.Dto/PagedData.cs
+++ b/src/NetCorePal.Extensions.Dto/PagedData.cs
@@ -1,4 +1,6 @@
-﻿namespace NetCorePal.Extensions.Dto;
+﻿using System.Text.Json.Serialization;
+
+namespace NetCorePal.Extensions.Dto;
 
 /// <summary>
 /// 分页数据模型
@@ -13,6 +15,7 @@ public class PagedData<T>
     /// <param name="total">总数据条数</param>
     /// <param name="pageIndex">当前页码，从1开始</param>
     /// <param name="pageSize">每页条数</param>
+    [JsonConstructor]
     public PagedData(IEnumerable<T> items, int total, int pageIndex, int pageSize)
     {
         Items = items;
@@ -20,18 +23,27 @@ public class PagedData<T>
         PageIndex = pageIndex;
         PageSize = pageSize;
     }
+
+    public PagedData()
+    {
+        Items = [];
+    }
+
     /// <summary>
     /// 分页数据
     /// </summary>
     public IEnumerable<T> Items { get; private set; }
+
     /// <summary>
     /// 数据总数
     /// </summary>
     public int Total { get; private set; }
+
     /// <summary>
     /// 当前页码，从1开始
     /// </summary>
     public int PageIndex { get; private set; }
+
     /// <summary>
     /// 每页数据条数
     /// </summary>


### PR DESCRIPTION
1. **`Entity.cs`（`NetCorePal.Extensions.Domain` 命名空间）**  
   - 将 `_domainEvents` 的初始化方式改为 `集合表达式`。
   - 将 `AddDomainEvent` 方法的访问修饰符从 `public` 修改为 `protected`，增强封装性，限制外部调用。
   - 在 `Entity<TKey>` 类中， `GetKeys` 方法修改为使用 `集合表达式`

2. **`PagedData.cs`（`NetCorePal.Extensions.Domain` 命名空间）**
   - 在 `PagedData<T>` 类中新增无参构造函数。