### PR TITLE
feat: validation for cap transaction factory registration 添加CAP注册校验

### DIFF
--- a/src/DistributedTransactions.CAP.MySql/CapBuilderExtensions.cs
+++ b/src/DistributedTransactions.CAP.MySql/CapBuilderExtensions.cs
@@ -13,6 +13,11 @@ namespace NetCorePal.Extensions.DependencyInjection
         /// <returns></returns>
         public static ICapBuilder UseMySql(this ICapBuilder builder)
         {
+            if (builder.Services.Any(p => p.ServiceType == typeof(ICapTransactionFactory)))
+            {
+                throw new InvalidOperationException(R.RepeatAddition);
+            }
+
             builder.Services.TryAddScoped<ICapTransactionFactory, MySqlCapTransactionFactory>();
             return builder;
         }

--- a/src/DistributedTransactions.CAP.MySql/NetCorePal.Extensions.DistributedTransactions.CAP.MySql.csproj
+++ b/src/DistributedTransactions.CAP.MySql/NetCorePal.Extensions.DistributedTransactions.CAP.MySql.csproj
@@ -11,4 +11,17 @@
   <ItemGroup>
     <ProjectReference Include="..\DistributedTransactions.CAP\NetCorePal.Extensions.DistributedTransactions.CAP.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="R.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>R.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="R.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>R.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/DistributedTransactions.CAP.MySql/Properties/AssemblyInfo.cs
+++ b/src/DistributedTransactions.CAP.MySql/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.MySql.UnitTests")]

--- a/src/DistributedTransactions.CAP.MySql/R.Designer.cs
+++ b/src/DistributedTransactions.CAP.MySql/R.Designer.cs
@@ -7,7 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace NetCorePal.Extensions.DistributedTransactions.CAP {
+namespace NetCorePal.Extensions.DistributedTransactions.CAP.MySql {
     using System;
     
     
@@ -28,7 +28,7 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
         internal static System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.Equals(null, resourceMan)) {
-                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.R", typeof(R).Assembly);
+                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.MySql.R", typeof(R).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -42,18 +42,6 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
             }
             set {
                 resourceCulture = value;
-            }
-        }
-        
-        internal static string InvalidTableName {
-            get {
-                return ResourceManager.GetString("InvalidTableName", resourceCulture);
-            }
-        }
-        
-        internal static string TransactionNotSupport {
-            get {
-                return ResourceManager.GetString("TransactionNotSupport", resourceCulture);
             }
         }
         

--- a/src/DistributedTransactions.CAP.MySql/R.resx
+++ b/src/DistributedTransactions.CAP.MySql/R.resx
@@ -1,4 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
     <resheader name="resmimetype">
         <value>text/microsoft-resx</value>
     </resheader>
@@ -11,13 +18,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>When using UseNetCorePalStorage, there is no need to additionally register UseMySql.</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP.MySql/R.zh.resx
+++ b/src/DistributedTransactions.CAP.MySql/R.zh.resx
@@ -11,13 +11,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql。</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP.PostgreSql/CapBuilderExtensions.cs
+++ b/src/DistributedTransactions.CAP.PostgreSql/CapBuilderExtensions.cs
@@ -13,6 +13,11 @@ namespace NetCorePal.Extensions.DependencyInjection
         /// <returns></returns>
         public static ICapBuilder UsePostgreSql(this ICapBuilder builder)
         {
+            if (builder.Services.Any(p => p.ServiceType == typeof(ICapTransactionFactory)))
+            {
+                throw new InvalidOperationException(R.RepeatAddition);
+            }
+
             builder.Services.TryAddScoped<ICapTransactionFactory, PostgreSqlCapTransactionFactory>();
             return builder;
         }

--- a/src/DistributedTransactions.CAP.PostgreSql/NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql.csproj
+++ b/src/DistributedTransactions.CAP.PostgreSql/NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql.csproj
@@ -11,4 +11,17 @@
   <ItemGroup>
     <ProjectReference Include="..\DistributedTransactions.CAP\NetCorePal.Extensions.DistributedTransactions.CAP.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="R.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>R.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="R.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>R.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/DistributedTransactions.CAP.PostgreSql/Properties/AssemblyInfo.cs
+++ b/src/DistributedTransactions.CAP.PostgreSql/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql.UnitTests")]

--- a/src/DistributedTransactions.CAP.PostgreSql/R.Designer.cs
+++ b/src/DistributedTransactions.CAP.PostgreSql/R.Designer.cs
@@ -7,7 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace NetCorePal.Extensions.DistributedTransactions.CAP {
+namespace NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql {
     using System;
     
     
@@ -28,7 +28,7 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
         internal static System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.Equals(null, resourceMan)) {
-                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.R", typeof(R).Assembly);
+                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql.R", typeof(R).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -42,18 +42,6 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
             }
             set {
                 resourceCulture = value;
-            }
-        }
-        
-        internal static string InvalidTableName {
-            get {
-                return ResourceManager.GetString("InvalidTableName", resourceCulture);
-            }
-        }
-        
-        internal static string TransactionNotSupport {
-            get {
-                return ResourceManager.GetString("TransactionNotSupport", resourceCulture);
             }
         }
         

--- a/src/DistributedTransactions.CAP.PostgreSql/R.resx
+++ b/src/DistributedTransactions.CAP.PostgreSql/R.resx
@@ -1,4 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
     <resheader name="resmimetype">
         <value>text/microsoft-resx</value>
     </resheader>
@@ -11,13 +18,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>When using UseNetCorePalStorage, there is no need to additionally register UsePostgreSql.</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP.PostgreSql/R.zh.resx
+++ b/src/DistributedTransactions.CAP.PostgreSql/R.zh.resx
@@ -11,13 +11,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>使用UseNetCorePalStorage时，不需要额外注册UsePostgreSql。</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP.SqlServer/CapBuilderExtensions.cs
+++ b/src/DistributedTransactions.CAP.SqlServer/CapBuilderExtensions.cs
@@ -13,6 +13,11 @@ namespace NetCorePal.Extensions.DependencyInjection
         /// <returns></returns>
         public static ICapBuilder UseSqlServer(this ICapBuilder builder)
         {
+            if (builder.Services.Any(p => p.ServiceType == typeof(ICapTransactionFactory)))
+            {
+                throw new InvalidOperationException(R.RepeatAddition);
+            }
+
             builder.Services.TryAddScoped<ICapTransactionFactory, SqlServerCapTransactionFactory>();
             return builder;
         }

--- a/src/DistributedTransactions.CAP.SqlServer/NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.csproj
+++ b/src/DistributedTransactions.CAP.SqlServer/NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.csproj
@@ -11,4 +11,17 @@
   <ItemGroup>
     <ProjectReference Include="..\DistributedTransactions.CAP\NetCorePal.Extensions.DistributedTransactions.CAP.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="R.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>R.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="R.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>R.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/DistributedTransactions.CAP.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/DistributedTransactions.CAP.SqlServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.UnitTests")]

--- a/src/DistributedTransactions.CAP.SqlServer/R.Designer.cs
+++ b/src/DistributedTransactions.CAP.SqlServer/R.Designer.cs
@@ -7,7 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace NetCorePal.Extensions.DistributedTransactions.CAP {
+namespace NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer {
     using System;
     
     
@@ -28,7 +28,7 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
         internal static System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.Equals(null, resourceMan)) {
-                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.R", typeof(R).Assembly);
+                    System.Resources.ResourceManager temp = new System.Resources.ResourceManager("NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.R", typeof(R).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -42,18 +42,6 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP {
             }
             set {
                 resourceCulture = value;
-            }
-        }
-        
-        internal static string InvalidTableName {
-            get {
-                return ResourceManager.GetString("InvalidTableName", resourceCulture);
-            }
-        }
-        
-        internal static string TransactionNotSupport {
-            get {
-                return ResourceManager.GetString("TransactionNotSupport", resourceCulture);
             }
         }
         

--- a/src/DistributedTransactions.CAP.SqlServer/R.resx
+++ b/src/DistributedTransactions.CAP.SqlServer/R.resx
@@ -1,4 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
     <resheader name="resmimetype">
         <value>text/microsoft-resx</value>
     </resheader>
@@ -11,13 +18,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>When using UseNetCorePalStorage, there is no need to additionally register UseSqlServer.</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP.SqlServer/R.zh.resx
+++ b/src/DistributedTransactions.CAP.SqlServer/R.zh.resx
@@ -11,13 +11,7 @@
     <resheader name="writer">
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
-    <data name="InvalidTableName" xml:space="preserve">
-        <value>不合法的表名: {0}</value>
-    </data>
-    <data name="TransactionNotSupport" xml:space="preserve">
-        <value>这个方法目前未实现事务参数的支持。</value>
-    </data>
     <data name="RepeatAddition" xml:space="preserve">
-        <value>使用UseNetCorePalStorage时，不需要额外注册UseMySql、UsePostgreSql、UseSqlServer等。</value>
+        <value>使用UseNetCorePalStorage时，不需要额外注册UseSqlServer。</value>
     </data>
 </root>

--- a/src/DistributedTransactions.CAP/Persistence/NetCorePalCapOptionsExtension.cs
+++ b/src/DistributedTransactions.CAP/Persistence/NetCorePalCapOptionsExtension.cs
@@ -16,6 +16,11 @@ public class NetCorePalCapOptionsExtension<TDbContext> : ICapOptionsExtension
         services.AddSingleton(new CapStorageMarkerService("NetCorePal"));
         services.AddSingleton<IDataStorage, NetCorePalDataStorage<TDbContext>>();
         services.TryAddSingleton<IStorageInitializer, NetCorePalStorageInitializer>();
+        if (services.Any(p => p.ServiceType == typeof(ICapTransactionFactory)))
+        {
+            throw new InvalidOperationException(R.RepeatAddition);
+        }
+
         services.TryAddScoped<ICapTransactionFactory, NetCorePalCapTransactionFactory>();
     }
 }

--- a/src/DistributedTransactions.CAP/Properties/AssemblyInfo.cs
+++ b/src/DistributedTransactions.CAP/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.MySql.UnitTests")]
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.PostgreSql.UnitTests")]
+[assembly: InternalsVisibleTo("NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.UnitTests")]

--- a/src/DistributedTransactions.CAP/R.resx
+++ b/src/DistributedTransactions.CAP/R.resx
@@ -24,4 +24,7 @@
     <data name="TransactionNotSupport" xml:space="preserve">
         <value>Transaction is not supported in this method.</value>
     </data>
+    <data name="RepeatAddition" xml:space="preserve">
+        <value>When using UseNetCorePalStorage, there is no need to additionally register UseMySql, UsePostgreSql, UseSqlServer, etc.</value>
+    </data>
 </root>

--- a/test/NetCorePal.Extensions.DistributedTransactions.CAP.MySql.UnitTests/UseMySqlTests.cs
+++ b/test/NetCorePal.Extensions.DistributedTransactions.CAP.MySql.UnitTests/UseMySqlTests.cs
@@ -37,4 +37,61 @@ public class UseMySqlTests
         var handler = provider.GetRequiredService<ICapTransactionFactory>();
         Assert.IsType<MySqlCapTransactionFactory>(handler);
     }
+
+    [Fact]
+    public void UseMySql_Should_Failed_When_UseNetCorePalStorage_First()
+    {
+        IServiceCollection services = new ServiceCollection();
+        ConfigurationBuilder configurationBuilder = new();
+        configurationBuilder.AddJsonFile("appsettings.json", optional: true);
+        IConfigurationRoot configurationRoot = configurationBuilder.Build();
+        services.AddLogging();
+        services.AddDbContext<NetCorePalDataStorageDbContext>(c =>
+        {
+            c.UseMySql("Server=any;User ID=any;Password=any;Database=any", new MySqlServerVersion("8.0.34"));
+        });
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+        services.AddCap(x =>
+        {
+            x.UseNetCorePalStorage<NetCorePalDataStorageDbContext>();
+            x.UseRabbitMQ(p => configurationRoot.GetSection("RabbitMQ").Bind(p));
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.AddIntegrationEvents(typeof(UseMySqlTests))
+                .UseCap<NetCorePalDataStorageDbContext>(b => b.UseMySql());
+        });
+
+        Assert.Equal(R.RepeatAddition, ex.Message);
+    }
+
+    [Fact]
+    public void UseNetCorePalStorage_Should_Failed_When_UseMySql_First()
+    {
+        IServiceCollection services = new ServiceCollection();
+        ConfigurationBuilder configurationBuilder = new();
+        configurationBuilder.AddJsonFile("appsettings.json", optional: true);
+        IConfigurationRoot configurationRoot = configurationBuilder.Build();
+        services.AddLogging();
+        services.AddDbContext<NetCorePalDataStorageDbContext>(c =>
+        {
+            c.UseMySql("Server=any;User ID=any;Password=any;Database=any", new MySqlServerVersion("8.0.34"));
+        });
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+
+        services.AddIntegrationEvents(typeof(UseMySqlTests))
+            .UseCap<NetCorePalDataStorageDbContext>(b => b.UseMySql());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.AddCap(x =>
+            {
+                x.UseNetCorePalStorage<NetCorePalDataStorageDbContext>();
+                x.UseRabbitMQ(p => configurationRoot.GetSection("RabbitMQ").Bind(p));
+            });
+        });
+
+        Assert.Equal(NetCorePal.Extensions.DistributedTransactions.CAP.R.RepeatAddition, ex.Message);
+    }
 }

--- a/test/NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.UnitTests/UseSqlServerTests.cs
+++ b/test/NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.UnitTests/UseSqlServerTests.cs
@@ -33,5 +33,56 @@ namespace NetCorePal.Extensions.DistributedTransactions.CAP.SqlServer.UnitTests
             var handler = provider.GetRequiredService<ICapTransactionFactory>();
             Assert.IsType<SqlServerCapTransactionFactory>(handler);
         }
+
+        [Fact]
+        public void UseSqlServer_Should_Failed_When_UseNetCorePalStorage_First()
+        {
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder configurationBuilder = new();
+            configurationBuilder.AddJsonFile("appsettings.json", optional: true);
+            IConfigurationRoot configurationRoot = configurationBuilder.Build();
+            services.AddLogging();
+            services.AddDbContext<NetCorePalDataStorageDbContext>(c => { c.UseSqlServer("localhost"); });
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+            services.AddCap(x =>
+            {
+                x.UseNetCorePalStorage<NetCorePalDataStorageDbContext>();
+                x.UseRabbitMQ(p => configurationRoot.GetSection("RabbitMQ").Bind(p));
+            });
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                services.AddIntegrationEvents(typeof(UseSqlServerTests))
+                    .UseCap<NetCorePalDataStorageDbContext>(b => b.UseSqlServer());
+            });
+
+            Assert.Equal(R.RepeatAddition, ex.Message);
+        }
+
+        [Fact]
+        public void UseNetCorePalStorage_Should_Failed_When_UseSqlServer_First()
+        {
+            IServiceCollection services = new ServiceCollection();
+            ConfigurationBuilder configurationBuilder = new();
+            configurationBuilder.AddJsonFile("appsettings.json", optional: true);
+            IConfigurationRoot configurationRoot = configurationBuilder.Build();
+            services.AddLogging();
+            services.AddDbContext<NetCorePalDataStorageDbContext>(c => { c.UseSqlServer("localhost"); });
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+
+            services.AddIntegrationEvents(typeof(UseSqlServerTests))
+                .UseCap<NetCorePalDataStorageDbContext>(b => b.UseSqlServer());
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                services.AddCap(x =>
+                {
+                    x.UseNetCorePalStorage<NetCorePalDataStorageDbContext>();
+                    x.UseRabbitMQ(p => configurationRoot.GetSection("RabbitMQ").Bind(p));
+                });
+            });
+
+            Assert.Equal(NetCorePal.Extensions.DistributedTransactions.CAP.R.RepeatAddition, ex.Message);
+        }
     }
 }


### PR DESCRIPTION
添加CAP注册校验，避免使用NetCorePalStorage时，重复注册`ICapTransactionFactory` 的问题。

#224 

This pull request introduces changes to enhance error handling, resource management, and testability across the `DistributedTransactions.CAP` project. The most significant updates include adding checks to prevent duplicate service registrations, introducing localized resource files for error messages, and enabling internal visibility for unit testing.

### Error Handling Improvements:
* Added validation in `CapBuilderExtensions` for MySQL, PostgreSQL, and SQL Server to prevent duplicate registrations of `ICapTransactionFactory`. An `InvalidOperationException` with a localized message is thrown if a duplicate is detected. (`src/DistributedTransactions.CAP.MySql/CapBuilderExtensions.cs` - [[1]](diffhunk://#diff-837199324ac3d9ff8d2a4e597ebfb8417f087bdbc7fd869be1dabd15eed0c0bfR16-R20) `src/DistributedTransactions.CAP.PostgreSql/CapBuilderExtensions.cs` - [[2]](diffhunk://#diff-3b883e55cb170d58e3db60cd1ff5141f89ff69bd14f3a9c0a28332f5e97df82fR16-R20) `src/DistributedTransactions.CAP.SqlServer/CapBuilderExtensions.cs` - [[3]](diffhunk://#diff-a0ad4cff3595ad49acc42fe7e872caa51890ec437af38f1577c72ac926acc83bR16-R20)
* Added a similar validation in `NetCorePalCapOptionsExtension` to prevent duplicate `ICapTransactionFactory` registrations when using `NetCorePalStorage`. (`src/DistributedTransactions.CAP/Persistence/NetCorePalCapOptionsExtension.cs` - [src/DistributedTransactions.CAP/Persistence/NetCorePalCapOptionsExtension.csR19-R23](diffhunk://#diff-5109f1e80efeecc458f5581ca9d2f367d9cdd3f11b3965ca4e818f31a419eb9cR19-R23))

### Resource Management:
* Introduced localized resource files (`R.resx`) and their strongly-typed counterparts (`R.Designer.cs`) for MySQL, PostgreSQL, and SQL Server projects to manage error messages like `RepeatAddition`. This includes support for both default and Chinese (`R.zh.resx`) localizations. (`src/DistributedTransactions.CAP.MySql/R.resx` - [[1]](diffhunk://#diff-fc3046e48a8ee795bfe460def292f63d6d61298565e737efa5e3d5be93e0f5c7R1-R24) `src/DistributedTransactions.CAP.MySql/R.zh.resx` - [[2]](diffhunk://#diff-1a35ff1bcd6205c9f71bcd4b0de7a77825cba2c4378c7fc0e5239531eaaace4fR1-R17) `src/DistributedTransactions.CAP.PostgreSql/R.resx` - [[3]](diffhunk://#diff-d34a65fe0db292aa4f352197961bc59094996e7940ba847b5f21824470ce9709R1-R24) `src/DistributedTransactions.CAP.PostgreSql/R.zh.resx` - [[4]](diffhunk://#diff-64af61a969df6b931a65b85078ad5012e9347393c10514d9ec6cceb5b0c2aa72R1-R17) `src/DistributedTransactions.CAP.SqlServer/R.resx` - [[5]](diffhunk://#diff-f79e06020c87b504866021570877b7e5d5ba651232aa791bece59e1cd50136a9R1-R24) `src/DistributedTransactions.CAP.SqlServer/R.zh.resx` - [[6]](diffhunk://#diff-2fa7c23b85bb8e85b7abd02b7a8de5815b9975644de8377aea18c4850d3c2292R1-R17)

### Testability Enhancements:
* Enabled `InternalsVisibleTo` for unit test projects in each database-specific implementation and the core project, allowing unit tests to access internal members. (`src/DistributedTransactions.CAP.MySql/Properties/AssemblyInfo.cs` - [[1]](diffhunk://#diff-f6a32d9c4752296fb14537a999410de2e23b535dcc6055ca48a03e0595b9df68R1-R3) `src/DistributedTransactions.CAP.PostgreSql/Properties/AssemblyInfo.cs` - [[2]](diffhunk://#diff-c592657b9124451c9b219bbd9c56ecd03626128d384a73470e7d43aed7e7f049R1-R3) `src/DistributedTransactions.CAP.SqlServer/Properties/AssemblyInfo.cs` - [[3]](diffhunk://#diff-9599ed510a8b164efa648e467f1806f7643bdc88e5797b5a02a72cba8d104392R1-R3) `src/DistributedTransactions.CAP/Properties/AssemblyInfo.cs` - [[4]](diffhunk://#diff-82e03fb7392b6c93f6bc3be6d65e86fe74ab651ad7596124d6d329dca050e626R1-R5)