### PR TITLE
调整强类型Id源生成器

### DIFF
--- a/src/Domain.SourceGenerators/EntityIdCodeGenerators.cs
+++ b/src/Domain.SourceGenerators/EntityIdCodeGenerators.cs
@@ -84,7 +84,7 @@ namespace {ns}
     /// </summary>
     /// <param name=""Id"">The Inner Id</param>
     [TypeConverter(typeof(EntityIdTypeConverter<{className}, {sourceType}>))]
-    public partial record {className}({sourceType} Id) : I{sourceType}StronglyTypedId
+    public partial record {className}({sourceType} Id)
     {{
         ///// <summary>
         ///// implicit operator

--- a/test/NetCorePal.SourceGenerator.UnitTests/DomainIdGeneratorTests.cs
+++ b/test/NetCorePal.SourceGenerator.UnitTests/DomainIdGeneratorTests.cs
@@ -19,7 +19,7 @@ namespace NetCorePal.SourceGenerator.UnitTests
 
             var generatedCode = RunGenerator(source);
 
-            Assert.Contains("public partial record TestEntity(Int64 Id) : IInt64StronglyTypedId", generatedCode);
+            Assert.Contains("public partial record TestEntity(Int64 Id)", generatedCode);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace NetCorePal.SourceGenerator.UnitTests
 
             var generatedCode = RunGenerator(source);
 
-            Assert.Contains("public partial record TestEntity(Int32 Id) : IInt32StronglyTypedId", generatedCode);
+            Assert.Contains("public partial record TestEntity(Int32 Id)", generatedCode);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace NetCorePal.SourceGenerator.UnitTests
 
             var generatedCode = RunGenerator(source);
 
-            Assert.Contains("public partial record TestEntity(String Id) : IStringStronglyTypedId", generatedCode);
+            Assert.Contains("public partial record TestEntity(String Id)", generatedCode);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace NetCorePal.SourceGenerator.UnitTests
 
             var generatedCode = RunGenerator(source);
 
-            Assert.Contains("public partial record TestEntity(Guid Id) : IGuidStronglyTypedId", generatedCode);
+            Assert.Contains("public partial record TestEntity(Guid Id)", generatedCode);
         }
 
         private string RunGenerator(string source)


### PR DESCRIPTION
调整强类型Id源生成器：移除重复接口实现，用于修复编译器提示 “基类型 'I{sourceType}tronglyTypedId' 已在其他部分中指定”