### PR TITLE
feat: NetCorePal.Extensions.CodeAnalysis.Tools 依赖的版本号保持一致

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -128,7 +128,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
-    <PackageVersion Include="NetCorePal.Extensions.CodeAnalysis" Version="2.8.1" /> 
     
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/eng/versions.props
+++ b/eng/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.8.3</VersionPrefix>
+    <VersionPrefix>2.8.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/NetCorePal.Extensions.CodeAnalysis.Tools/NetCorePal.Extensions.CodeAnalysis.Tools.csproj
+++ b/src/NetCorePal.Extensions.CodeAnalysis.Tools/NetCorePal.Extensions.CodeAnalysis.Tools.csproj
@@ -10,8 +10,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="NetCorePal.Extensions.CodeAnalysis" />
     <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NetCorePal.Extensions.CodeAnalysis\NetCorePal.Extensions.CodeAnalysis.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes changes to update dependencies and modify project references for better alignment and maintenance. The most important changes involve removing a package reference, updating the version prefix, and replacing a `PackageReference` with a `ProjectReference`.

### Dependency Updates:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L131): Removed the package version entry for `NetCorePal.Extensions.CodeAnalysis`.
* [`eng/versions.props`](diffhunk://#diff-299d8fbf2a765f998e979463ec3b3f91934fc3834f6171d3e27363b87123f90aL3-R3): Updated the `VersionPrefix` from `2.8.3` to `2.8.4` to reflect the new versioning scheme.

### Project Reference Modifications:

* [`src/NetCorePal.Extensions.CodeAnalysis.Tools/NetCorePal.Extensions.CodeAnalysis.Tools.csproj`](diffhunk://#diff-dd38a9cd0226cdd34728f2540c8fa7f195dacfd2e466495b5012f2b62d4515dcL13-R19): Replaced the `PackageReference` for `NetCorePal.Extensions.CodeAnalysis` with a `ProjectReference` pointing to its corresponding `.csproj` file, ensuring direct project linkage instead of a package dependency.