### PR TITLE
CodeAnalysis Tool

### DIFF
--- a/eng/versions.props
+++ b/eng/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.9.2</VersionPrefix>
+    <VersionPrefix>2.9.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/NetCorePal.Extensions.CodeAnalysis.Tools/NetCorePal.Extensions.CodeAnalysis.Tools.csproj
+++ b/src/NetCorePal.Extensions.CodeAnalysis.Tools/NetCorePal.Extensions.CodeAnalysis.Tools.csproj
@@ -12,5 +12,9 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\NetCorePal.Extensions.CodeAnalysis\NetCorePal.Extensions.CodeAnalysis.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/NetCorePal.Extensions.CodeAnalysis.Tools/Program.cs
+++ b/src/NetCorePal.Extensions.CodeAnalysis.Tools/Program.cs
@@ -327,11 +327,27 @@ public class Program
 
             try
             {
-                var assembly = Assembly.LoadFrom(assemblyFile.FullName);
-                assemblies.Add(assembly);
-                if (verbose)
+                // 检查是否已经加载过相同路径的程序集
+                var normalizedPath = Path.GetFullPath(assemblyFile.FullName);
+                var alreadyLoaded = assemblies.Any(a => 
+                    !string.IsNullOrEmpty(a.Location) && 
+                    Path.GetFullPath(a.Location).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+                    
+                if (alreadyLoaded)
                 {
-                    Console.WriteLine($"  Loaded assembly: {assembly.FullName}");
+                    if (verbose)
+                    {
+                        Console.WriteLine($"  Skipping already loaded assembly: {assemblyFile.Name}");
+                    }
+                }
+                else
+                {
+                    var assembly = Assembly.LoadFrom(assemblyFile.FullName);
+                    assemblies.Add(assembly);
+                    if (verbose)
+                    {
+                        Console.WriteLine($"  Loaded assembly: {assembly.FullName}");
+                    }
                 }
             }
             catch (Exception ex)
@@ -425,11 +441,27 @@ public class Program
                 {
                     try
                     {
-                        var assembly = Assembly.LoadFrom(assemblyFile);
-                        assemblies.Add(assembly);
-                        if (verbose)
+                        // 检查是否已经加载过相同路径的程序集
+                        var normalizedPath = Path.GetFullPath(assemblyFile);
+                        var alreadyLoaded = assemblies.Any(a => 
+                            !string.IsNullOrEmpty(a.Location) && 
+                            Path.GetFullPath(a.Location).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+                            
+                        if (alreadyLoaded)
                         {
-                            Console.WriteLine($"    Loaded: {Path.GetFileName(assemblyFile)}");
+                            if (verbose)
+                            {
+                                Console.WriteLine($"    Skipping already loaded: {Path.GetFileName(assemblyFile)}");
+                            }
+                        }
+                        else
+                        {
+                            var assembly = Assembly.LoadFrom(assemblyFile);
+                            assemblies.Add(assembly);
+                            if (verbose)
+                            {
+                                Console.WriteLine($"    Loaded: {Path.GetFileName(assemblyFile)}");
+                            }
                         }
                     }
                     catch (Exception ex)
@@ -878,11 +910,27 @@ public class Program
             {
                 try
                 {
-                    var assembly = Assembly.LoadFrom(assemblyPath);
-                    assemblies.Add(assembly);
-                    if (verbose)
+                    // 检查是否已经加载过相同路径的程序集
+                    var normalizedPath = Path.GetFullPath(assemblyPath);
+                    var alreadyLoaded = assemblies.Any(a => 
+                        !string.IsNullOrEmpty(a.Location) && 
+                        Path.GetFullPath(a.Location).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+                        
+                    if (alreadyLoaded)
                     {
-                        Console.WriteLine($"    Loaded: {projectName}.dll ({framework})");
+                        if (verbose)
+                        {
+                            Console.WriteLine($"    Skipping already loaded assembly: {projectName}.dll ({framework})");
+                        }
+                    }
+                    else
+                    {
+                        var assembly = Assembly.LoadFrom(assemblyPath);
+                        assemblies.Add(assembly);
+                        if (verbose)
+                        {
+                            Console.WriteLine($"    Loaded: {projectName}.dll ({framework})");
+                        }
                     }
                 }
                 catch (Exception ex)

--- a/src/NetCorePal.Extensions.CodeAnalysis/CodeFlowAnalysisHelper.cs
+++ b/src/NetCorePal.Extensions.CodeAnalysis/CodeFlowAnalysisHelper.cs
@@ -268,9 +268,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 直接通过 CommandHandlerMetadataAttribute 建立命令与聚合根的关系
             var handlerAttrs = attributes.OfType<CommandHandlerMetadataAttribute>().ToList();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Aggregate && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var handlerAttr in handlerAttrs)
@@ -303,9 +303,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 ControllerMethodMetadataAttribute 中实际存在的 Controller-Command 关系
             var controllerAttrs = attributes.OfType<ControllerMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.Controller && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in controllerAttrs)
@@ -332,9 +332,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 ControllerMethodMetadataAttribute 中实际存在的 ControllerMethod-Command 关系
             var controllerMethodAttrs = attributes.OfType<ControllerMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.ControllerMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in controllerMethodAttrs)
@@ -362,9 +362,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 EndpointMetadataAttribute 中实际存在的 Endpoint-Command 关系
             var endpointAttrs = attributes.OfType<EndpointMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.Endpoint && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in endpointAttrs)
@@ -392,9 +392,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 CommandSenderMethodMetadataAttribute 中实际存在的 CommandSender-Command 关系
             var senderMethodAttrs = attributes.OfType<CommandSenderMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.CommandSender && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in senderMethodAttrs)
@@ -422,9 +422,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 CommandSenderMethodMetadataAttribute 中实际存在的 CommandSenderMethod-Command 关系
             var senderMethodAttrs = attributes.OfType<CommandSenderMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.CommandSenderMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in senderMethodAttrs)
@@ -453,9 +453,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 CommandHandlerEntityMethodMetadataAttribute 中实际存在的 Command-EntityMethod 关系
             var handlerEntityMethodAttrs = attributes.OfType<CommandHandlerEntityMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.EntityMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in handlerEntityMethodAttrs)
@@ -482,9 +482,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             IEnumerable<Node> toNodes, IEnumerable<MetadataAttribute> attributes)
         {
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.Aggregate && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.DomainEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var aggregateNode in fromNodeDict)
@@ -523,9 +523,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 EntityMethodMetadataAttribute 中实际存在的 EntityMethod->EntityMethod 关系
             var entityMethodAttrs = attributes.OfType<EntityMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.EntityMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.EntityMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in entityMethodAttrs)
@@ -555,9 +555,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
             // 只生成 EntityMethodMetadataAttribute 中实际存在的 EntityMethod-DomainEvent 关系
             var entityMethodAttrs = attributes.OfType<EntityMethodMetadataAttribute>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.EntityMethod && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.DomainEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
 
             var relationships = new List<Relationship>();
             foreach (var attr in entityMethodAttrs)
@@ -586,9 +586,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
         {
             var relationships = new List<Relationship>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.DomainEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.DomainEventHandler && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var handlerMetas = attributes.OfType<DomainEventHandlerMetadataAttribute>().ToList();
             foreach (var handler in handlerMetas)
             {
@@ -616,9 +616,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
         {
             var relationships = new List<Relationship>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.DomainEventHandler && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var handlerMetas = attributes.OfType<DomainEventHandlerMetadataAttribute>().ToList();
             foreach (var handler in handlerMetas)
             {
@@ -645,9 +645,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
         {
             var relationships = new List<Relationship>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.IntegrationEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.IntegrationEventHandler && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var handlerMetas = attributes.OfType<IntegrationEventHandlerMetadataAttribute>().ToList();
             foreach (var handler in handlerMetas)
             {
@@ -675,9 +675,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
         {
             var relationships = new List<Relationship>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.IntegrationEventHandler && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.Command && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var handlerMetas = attributes.OfType<IntegrationEventHandlerMetadataAttribute>().ToList();
             foreach (var handler in handlerMetas)
             {
@@ -705,9 +705,9 @@ namespace NetCorePal.Extensions.CodeAnalysis
         {
             var relationships = new List<Relationship>();
             var fromNodeDict = fromNodes.Where(n => n.Type == NodeType.DomainEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var toNodeDict = toNodes.Where(n => n.Type == NodeType.IntegrationEvent && n.Id != null)
-                .ToDictionary(n => n.Id, n => n);
+                .GroupBy(n => n.Id).ToDictionary(g => g.Key, g => g.First());
             var converterMetas = attributes.OfType<IntegrationEventConverterMetadataAttribute>().ToList();
             foreach (var converter in converterMetas)
             {


### PR DESCRIPTION
This pull request introduces several improvements and robustness enhancements to the code analysis tool, focusing on more reliable assembly loading, improved build process handling, and better solution/project parsing. It also includes a version bump to `2.9.3`. The most important changes are grouped below:

**Assembly Loading Improvements:**

* Prevents duplicate assembly loading by checking if an assembly with the same file path has already been loaded in both manual and auto-discovery loading scenarios. This reduces errors and unnecessary processing. [[1]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4R329-R343) [[2]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4R443-R457)
* Adds robust error handling when analyzing assemblies: if an assembly fails to load or analyze, it is skipped and the analysis continues with the remaining assemblies, improving tool resilience.

**Build Process Robustness:**

* Refactors the build process for solutions and projects to use asynchronous output/error stream reading, sets timeouts (5 minutes for solutions, 3 minutes for projects), and provides clearer error messages and recovery if the build fails or times out. This prevents process hangs and buffer overflows. [[1]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4L415-R601) [[2]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4L463-R709)

**Solution and Project Parsing:**

* Adds a new method to accurately extract project paths from both traditional `.sln` and newer `.slnx` solution files, with a fallback to directory scanning if parsing fails. This ensures all relevant projects are discovered and analyzed.

**Code Consistency and Minor Enhancements:**

* Refactors code to consistently use static method calls instead of reflection for analysis and visualization, and improves variable naming for clarity. [[1]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4L173-R242) [[2]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4L225-R272) [[3]](diffhunk://#diff-39125a1337bb18084a8155dd22edf6b2056a357c14dcd8c802695e5822968eb4L236-R287)
* Bumps the version to `2.9.3` in `eng/versions.props`.