### PR TITLE
Remove unnecessary PackageReference from project file

### DIFF
--- a/src/NetCorePal.Extensions.Hangfire/NetCorePal.Extensions.Hangfire.csproj
+++ b/src/NetCorePal.Extensions.Hangfire/NetCorePal.Extensions.Hangfire.csproj
@@ -10,7 +10,6 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Hangfire.Core" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>


### PR DESCRIPTION
Removed PackageReference for Microsoft.Extensions.DependencyInjection.Abstractions.