### PR TITLE
修复: 更新 Star History 图表链接到新域名

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,4 +221,4 @@ https://www.myget.org/F/netcorepal/api/v3/index.json
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=netcorepal/netcorepal-cloud-framework&type=date&legend=top-left)](https://www.star-history.com/#netcorepal/netcorepal-cloud-framework&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=netcorepal/netcorepal-cloud-framework&type=date&legend=top-left)](https://star-history.dera.page/#netcorepal/netcorepal-cloud-framework&type=date&legend=top-left)


### PR DESCRIPTION
当前的 Star History 图表已损坏，原因是 GitHub stargazer API 的限制导致无法正常获取数据。此 PR 将图表链接切换到新的数据源域名，恢复 Star History 图表的正常显示。